### PR TITLE
feat: add sound alert with mute toggle for timer completion

### DIFF
--- a/js/pomodoro.js
+++ b/js/pomodoro.js
@@ -3,6 +3,7 @@ let timerInterval = null;
 let timeLeft = 25 * 60; // 25 minutes in seconds
 let isRunning = false;
 let isBreak = false;
+let isMuted = false;
 
 // DOM elements
 const timeDisplay = document.getElementById('timeDisplay');
@@ -13,6 +14,8 @@ const pauseBtn = document.getElementById('pauseBtn');
 const resetBtn = document.getElementById('resetBtn');
 const focusDuration = document.getElementById('focusDuration');
 const breakDuration = document.getElementById('breakDuration');
+const alertSound = new Audio("../alert.mp3")
+const muteBtn = document.getElementById('muteBtn');
 
 // Initialize
 document.addEventListener('DOMContentLoaded', () => {
@@ -24,6 +27,7 @@ function setupEventListeners() {
     startBtn.addEventListener('click', startTimer);
     pauseBtn.addEventListener('click', pauseTimer);
     resetBtn.addEventListener('click', resetTimer);
+    muteBtn.addEventListener('click', muteBtnToggle)
     
     focusDuration.addEventListener('change', () => {
         if (!isRunning) {
@@ -79,6 +83,10 @@ function completeSession() {
     
     if (!isBreak) {
         // Focus session completed, start break
+        if(!isMuted){
+            alertSound.play();
+            console.log("Sound played")
+        }
         alert('Great job! Time for a break.');
         isBreak = true;
         timeLeft = breakDuration.value * 60;
@@ -87,12 +95,16 @@ function completeSession() {
         timerCircle.style.background = 'linear-gradient(to bottom right, rgba(34, 211, 238, 0.2), rgba(6, 182, 212, 0.2))';
     } else {
         // Break completed
+        if(!isMuted){
+            alertSound.play();
+            console.log("Sound played")
+        }
         alert('Break over! Ready to focus again?');
         isBreak = false;
         timeLeft = focusDuration.value * 60;
         timerLabel.textContent = 'Focus Time';
         timerCircle.style.borderColor = '#10b981';
-        timerCircle.style.background = 'linear-gradient(to bottom right, rgba(16, 185, 129, 0.2), rgba(52, 211, 153, 0.2))';
+        timerCircle.style.background = 'linear-gradient(to bottom right, rgba(16, 185, 129, 0.2), rgba(29, 245, 166, 0.2))';
     }
     
     updateDisplay();
@@ -102,4 +114,16 @@ function updateDisplay() {
     const minutes = Math.floor(timeLeft / 60);
     const seconds = timeLeft % 60;
     timeDisplay.textContent = `${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
+}
+
+function muteBtnToggle(){
+    if(!isMuted) {
+        isMuted = true
+        console.log("Audio mutted")
+        muteBtn.textContent = "🔈"
+    }else if (isMuted){
+        isMuted = false
+        console.log("Audio is not muted")
+        muteBtn.textContent = "🔊"
+    }
 }

--- a/pomodoro.html
+++ b/pomodoro.html
@@ -41,6 +41,7 @@
                     <button id="startBtn" class="btn-timer btn-start">Start</button>
                     <button id="pauseBtn" class="btn-timer btn-pause hidden">Pause</button>
                     <button id="resetBtn" class="btn-timer btn-reset">Reset</button>
+                    <button id="muteBtn" class="btn-timer btn-start">🔊</button>
                 </div>
 
                 <div class="timer-settings">


### PR DESCRIPTION
### What this PR does
- Adds a sound alert when a focus or break timer completes
- Introduces a mute/unmute button to control audio playback
- Provides visual feedback using speaker icons (🔊 / 🔈)

### Why
This improves user feedback by notifying when a timer finishes, while still allowing users to disable sound if desired.

### How it works
- Plays an alert sound on timer completion
- Uses a boolean state to track mute status
- Toggles button icon based on mute state

### UI changes
- Added a mute/unmute button with icon toggle
